### PR TITLE
Add README. Update JRuby version. Bump version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-JRUBY_VERSION=1.7.10
+JRUBY_VERSION=1.7.11
 
 WITH_JRUBY=java -jar $(shell pwd)/$(JRUBY) -S
 JRUBY=vendor/jar/jruby-complete-$(JRUBY_VERSION).jar

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Logstash Contrib Repository
+
+This is a collection of companion plugins (and hopefully tests, too!) to be
+used in conjunction with [Logstash](https://github.com/elasticsearch/logstash).
+
+The plugins here are maintained by the core Logstash team, and supported by the 
+community.
+
+## Building
+
+The same build principles which exist in the core Logstash project will apply here.
+After installation plugins found herein will be end up in the same path as the core
+installation.  Building a tarball package is as simple as:
+
+```
+make tarball
+```
+
+The resulting package will be found in the `build` directory.
+
+## Project Principles
+
+* Community: If a newbie has a bad time, it's a bug.
+* Software: Make it work, then make it right, then make it fast.
+* Technology: If it doesn't do a thing today, we can make it do it tomorrow.
+
+## Contributing
+
+All contributions are welcome: ideas, patches, documentation, bug reports,
+complaints, and even something you drew up on a napkin.
+
+Programming is not a required skill. Whatever you've seen about open source and
+maintainers or community members  saying "send patches or die" - you will not
+see that here.
+
+It is more important to me that you are able to contribute.
+
+For more information about contributing, see the
+[CONTRIBUTING](https://github.com/elasticsearch/logstash/blob/master/CONTRIBUTING.md) file.

--- a/lib/logstash/version.rb
+++ b/lib/logstash/version.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 # The version of logstash.
-LOGSTASH_VERSION = "1.4.0.dev"
+LOGSTASH_VERSION = "1.4.0.beta1"
 
 # Note to authors: this should not include dashes because 'gem' barfs if
 # you include a dash in the version string.


### PR DESCRIPTION
The README is meant to mirror Logstash as much as is applicable.

Since JRuby was version bumped to 1.7.11 in core, we need to mirror that here.

Bumped the version to 1.4.0.beta1
