### PR TITLE
enable automatically mapping logstash fields to riemann event fields.

### DIFF
--- a/lib/logstash/outputs/riemann.rb
+++ b/lib/logstash/outputs/riemann.rb
@@ -2,7 +2,6 @@
 require "logstash/outputs/base"
 require "logstash/namespace"
 
-
 # Riemann is a network event stream processing system.
 #
 # While Riemann is very similar conceptually to Logstash, it has
@@ -68,6 +67,33 @@ class LogStash::Outputs::Riemann < LogStash::Outputs::Base
   # but can be overridden here.
   config :riemann_event, :validate => :hash
 
+  # If set to true automatically map all logstash defined fields to riemann event fields.
+  # All nested logstash fields will be mapped to riemann fields containing all parent keys
+  # separated by dots and the deepest value.
+  #
+  # As an example, the logstash event:
+  #    {
+  #      "@timestamp":"2013-12-10T14:36:26.151+0000",
+  #      "@version": 1,
+  #      "message":"log message",
+  #      "host": "host.domain.com",
+  #      "nested_field": {
+  #                        "key": "value"
+  #                      }
+  #    }
+  # Is mapped to this riemann event:
+  #   {
+  #     :time 1386686186,
+  #     :host host.domain.com,
+  #     :message log message,
+  #     :nested_field.key value
+  #   }
+  #
+  # It can be used in conjunction with or independent of the riemann_event option.
+  # When used with the riemann_event any duplicate keys receive their value from
+  # riemann_event instead of the logstash event itself.
+  config :map_fields, :validate => :boolean, :default => false
+
   #
   # Enable debugging output?
   config :debug, :validate => :boolean, :default => false
@@ -77,6 +103,21 @@ class LogStash::Outputs::Riemann < LogStash::Outputs::Base
     require 'riemann/client'
     @client = Riemann::Client.new(:host => @host, :port => @port)
   end # def register
+
+  public
+  def map_fields(parent, fields)
+    fields.each {|key, val|
+      if !key.start_with?("@")
+        field = parent.nil? ? key : parent + '.' + key
+        contents = val                            
+        if contents.is_a?(Hash)                                     
+          map_fields(field, contents)                                       
+        else                                                                                  
+          @my_event[field.to_sym] = contents                                                          
+        end
+      end
+    }                 
+  end
 
   public
   def receive(event)
@@ -96,6 +137,11 @@ class LogStash::Outputs::Riemann < LogStash::Outputs::Base
           r_event[key.to_sym] = event.sprintf(val)
         end
       end
+    end
+    if @map_fields == true
+      @my_event = Hash.new
+      map_fields(nil, event)
+      r_event.merge!(@my_event) {|key, val1, val2| val1}
     end
     r_event[:tags] = event["tags"] if event["tags"].is_a?(Array)
     @logger.debug("Riemann event: ", :riemann_event => r_event)


### PR DESCRIPTION
per the request from @electrical in PR #888, i'm submitting my patch for automatic riemann field mapping to logstash-contrib.
