### PR TITLE
fix undefined method `empty?` exception for Fixnum zbx messages

### DIFF
--- a/lib/logstash/outputs/zabbix.rb
+++ b/lib/logstash/outputs/zabbix.rb
@@ -125,7 +125,6 @@ class LogStash::Outputs::Zabbix < LogStash::Outputs::Base
 
         begin
           f = IO.popen(cmd, "a+")
-          f.close_write unless f.closed?
 
           command_output = f.gets
           command_processed = command_output[/processed: (\d+)/,1]


### PR DESCRIPTION
Fix for zabbix output plugin while using with metrics filter

For example, 

```
metrics {
    meter => [ "http.%{[response]}" ]
}
```

generates Fixnum values

```
"http.200.count": 2274,
...
"http.302.count": 3188,
...
"http.404.count": 25,
```
