### PR TITLE
Catch decode errors (websocket input)

### DIFF
--- a/lib/logstash/inputs/websocket.rb
+++ b/lib/logstash/inputs/websocket.rb
@@ -35,9 +35,16 @@ class LogStash::Inputs::Websocket < LogStash::Inputs::Base
     begin
       websocket = agent.websocket!(@url)
       websocket.each do |payload|
-        @codec.decode(payload) do |event|
-          decorate(event)
-          output_queue << event
+        next if payload == nil || payload.empty?
+        begin
+          @codec.decode(payload) do |event|
+            decorate(event)
+            output_queue << event
+          end
+        rescue => e
+          @logger.warn("decode threw exception, continue",
+                :exception => e)
+          next
         end
       end
     rescue => e


### PR DESCRIPTION
When decode errors happen (JSON,UTF,etc ) a new connection is established. Causing excessive connections on the server.
