### PR TITLE
A number of improvements to the Rackspace Cloud Queue Inputs/Outputs

### DIFF
--- a/lib/logstash/inputs/rackspace.rb
+++ b/lib/logstash/inputs/rackspace.rb
@@ -20,13 +20,20 @@ class LogStash::Inputs::Rackspace < LogStash::Inputs::Base
   # Rackspace Queue Name
   config :queue,  :validate => :string, :default => 'logstash'
 
-  # number of messages to claim
+  # Number of messages to claim
   # Min: 1, Max: 10
   config :claim,    :validate => :number, :default => 1
   
-  # length of time to hold claim
-  # Min: 60
+  # Length of time to hold claim in seconds
+  # Min: 60, Max: 43200 (12 hours)
   config :ttl,    :validate => :number, :default => 60
+
+  # Grace period for claim in seconds
+  # Min: 60, Max: 43200 (12 hours)
+  config :grace,  :validate => :number, :default => 60
+
+  # Polling interval in seconds (-1 to disable)
+  config :interval, :validate => :number, :default => 2
 
   public
   def register
@@ -59,10 +66,9 @@ class LogStash::Inputs::Rackspace < LogStash::Inputs::Base
   private
   def queue_event(msg, output_queue)
     begin
-      @codec.decode(msg.body.to_s) do |event|
-        decorate(event)
-        output_queue << event
-      end
+      event = LogStash::Event.new(msg.body)
+      decorate(event)
+      output_queue << event
       msg.destroy
     rescue => e # parse or event creation error
       @logger.error("Failed to create event", :message => msg, :exception => e,
@@ -73,12 +79,15 @@ class LogStash::Inputs::Rackspace < LogStash::Inputs::Base
   public
   def run(output_queue)
     while !finished?
-      claim = @rackspace_queue.claims.create :ttl => @ttl, :grace => 100, :limit => @claim
+      claim = @rackspace_queue.claims.create :ttl => @ttl, :grace => @grace, :limit => @claim
       if claim
         claim.messages.each do |message|
           queue_event message, output_queue
         end
       end # unless
+      if @interval > 0
+        sleep @interval
+      end # if
     end # while !finished
   end # def run
 

--- a/lib/logstash/inputs/rackspace.rb
+++ b/lib/logstash/inputs/rackspace.rb
@@ -17,7 +17,13 @@ class LogStash::Inputs::Rackspace < LogStash::Inputs::Base
   # ord, dfw, lon, syd, etc
   config :region, :validate => :string, :default => 'dfw'
 
-  # Rackspace Queue Name
+  # Rackspace queue name
+  #
+  # The name MUST NOT exceed 64 bytes in length, and is limited to
+  # US-ASCII letters, digits, underscores and hyphens.
+  #
+  # Note that there is a bug in Fog versions up to and including
+  # 1.21.0 that prevents usage with queue names that include a hyphen.
   config :queue,  :validate => :string, :default => 'logstash'
 
   # Number of messages to claim

--- a/lib/logstash/outputs/rackspace.rb
+++ b/lib/logstash/outputs/rackspace.rb
@@ -20,6 +20,12 @@ class LogStash::Outputs::Rackspace < LogStash::Outputs::Base
   config :region, :validate => :string, :default => 'dfw'
 
   # Rackspace queue name
+  #
+  # The name MUST NOT exceed 64 bytes in length, and is limited to
+  # US-ASCII letters, digits, underscores and hyphens.
+  #
+  # Note that there is a bug in Fog versions up to and including
+  # 1.21.0 that prevents usage with queue names that include a hyphen.
   config :queue,  :validate => :string, :default => 'logstash'
 
   # Time for item to live in queue

--- a/lib/logstash/outputs/rackspace.rb
+++ b/lib/logstash/outputs/rackspace.rb
@@ -1,13 +1,13 @@
 # encoding: utf-8
 require "logstash/outputs/base"
 require "logstash/namespace"
+require "stud/buffer"
 
 class LogStash::Outputs::Rackspace < LogStash::Outputs::Base
+  include Stud::Buffer
 
   config_name "rackspace"
   milestone 1
-
-  default :codec, "json"
 
   # Rackspace Cloud Username
   config :username, :validate => :string, :required => true
@@ -19,12 +19,30 @@ class LogStash::Outputs::Rackspace < LogStash::Outputs::Base
   # ord, dfw, lon, syd, etc
   config :region, :validate => :string, :default => 'dfw'
 
-  # Rackspace Queue Name
+  # Rackspace queue name
   config :queue,  :validate => :string, :default => 'logstash'
 
-  # time for item to live in queue
-  config :ttl,    :validate => :number, :default => 360
+  # Time for item to live in queue
+  # Min: 60, Max: 1209600 (14 days)
+  config :ttl,    :validate => :number, :default => 60
   
+  # To make efficient api calls, we will buffer a certain number of
+  # events before flushing that out to Rackspace. This setting
+  # controls how many events will be buffered before sending a batch
+  # of events.
+  config :flush_size, :validate => :number, :default => 10
+
+  # The amount of time since last flush before a flush is forced.
+  #
+  # This setting helps ensure slow event rates don't get stuck in Logstash.
+  # For example, if your `flush_size` is 100, and you have received 10 events,
+  # and it has been more than `idle_flush_time` seconds since the last flush,
+  # Logstash will flush those 10 events automatically.
+  #
+  # This helps keep both fast and slow log streams moving along in
+  # near-real-time.
+  config :idle_flush_time, :validate => :number, :default => 1
+
   public
   def register
     require "fog"
@@ -35,35 +53,71 @@ class LogStash::Outputs::Rackspace < LogStash::Outputs::Base
       :connection_options  => {}                     # Optional connection options
     )
 
-    begin
-      @rackspace_queue = @service.queues.create :name => @queue
-    rescue Fog::Rackspace::Queues::ServiceError => e
-      if e.status_code == 204
-        @logger.warn("Queue #{@queue} already exists")
-      else
-        @logger.warn("something bad happened!")
-      end # rescue
-    end # begin
-    @service.queues.each_with_index do |queue, index|
-      if queue.name == @queue
-        @rackspace_queue = @service.queues[index]
-        break
-      end
-    end
     @logger.info("Opened connection to rackspace cloud queues")
+
+    @queues = Hash.new
+
+    buffer_initialize(
+      :max_items => @flush_size,
+      :max_interval => @idle_flush_time,
+      :logger => @logger
+    )
   end # def register
 
   public
   def receive(event)
     return unless output?(event)
 
-    begin
-      @rackspace_queue.messages.create :body => event, :ttl => @ttl
-      #@rackspace_queue.messages.create :body => "some data here", :ttl => @ttl
-    rescue => e
-      @logger.warn("Failed to send event to rackspace cloud queues", :event => event, :exception => e,
-                   :backtrace => e.backtrace)
-    end
-
+    queue_name = event.sprintf(@queue)
+    buffer_receive({:body => event.to_hash, :ttl => @ttl}, :queue_name => queue_name )
   end # def receive
+
+  def get_queue(queue_name)
+    if @queues.has_key?(queue_name)
+      return @queues[queue_name]
+    end # if
+
+    @logger.warn("Using #{queue_name} for the first time")
+
+    begin
+      @service.queues.create :name => queue_name
+    rescue Fog::Rackspace::Queues::ServiceError => e
+      if e.status_code == 204
+        @logger.warn("Queue #{queue_name} already exists")
+      else
+        @logger.warn("something bad happened!")
+      end # if
+    end # begin
+    @service.queues.each_with_index do |queue, index|
+      if queue.name == queue_name
+        queue = @service.queues[index]
+        @queues[queue_name] = queue
+        return queue
+      end # if
+    end # do
+
+    return nil
+  end # def get_queue
+
+  def flush(messages, group, teardown=false)
+    # Fog is not currently able to post multiple messages in one API
+    # call. Until it can, post each message individually.
+    queue = get_queue(group[:queue_name])
+    messages.each do |message|
+      begin
+        queue.messages.create message
+      rescue => e
+        @logger.warn("Failed to send event to Rackspace cloud queues",
+                     :message => message,
+                     :queue_name => group[:queue_name],
+                     :exception => e,
+                     :backtrace => e.backtrace)
+      end # begin
+    end # do
+  end # def flush
+
+  def teardown
+    buffer_flush(:final => true)
+  end
+
 end # class LogStash::Outputs::Rackspace

--- a/logstash-contrib.gemspec
+++ b/logstash-contrib.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "jdbc-sqlite3"                     #(MIT license)
   gem.add_runtime_dependency "rsolr"                            #(Apache 2.0 license)
   gem.add_runtime_dependency "jmx4r"                            #(Apache 2.0 license)
-  gem.add_runtime_dependency "fog", ["1.20.0"]                 #(MIT license)
+  gem.add_runtime_dependency "fog", ["1.22.0"]                 #(MIT license)
 
   if RUBY_PLATFORM == 'java'
     gem.platform = RUBY_PLATFORM


### PR DESCRIPTION
1. Codec parameter is unnecessary as Rackspace Cloud Queues mandate
   JSON encapsulation.
2. Add ability to specify grace period in input
3. Add ability to specify a polling interval in the input (to limit
   the number of API calls per second).
4. Expand on the documentation for config parameters.
5. Add buffering to the output, although this doesn't take advantage
   of the Cloud Queues API being able to post multiple messages per
   API call as the underlying Fog library does not support that.
6. Add the ability to sprintf the queue name on output.
