### PR TITLE
Unable to compress timestamp in compress_spooler

### DIFF
--- a/lib/logstash/codecs/compress_spooler.rb
+++ b/lib/logstash/codecs/compress_spooler.rb
@@ -22,7 +22,8 @@ class LogStash::Codecs::CompressSpooler < LogStash::Codecs::Base
     z.close
     data.each do |event|
       event = LogStash::Event.new(event)
-      event["@timestamp"] = Time.at(event["@timestamp"]).utc if event["@timestamp"].is_a? Float
+      event["@timestamp"] = Time.at(event["@timestamp_f"]).utc if event["@timestamp_f"].is_a? Float
+      event.remove("@timestamp_f")
       yield event
     end
   end # def decode
@@ -35,7 +36,8 @@ class LogStash::Codecs::CompressSpooler < LogStash::Codecs::Base
       z.close
       @buffer.clear
     else
-      data["@timestamp"] = data["@timestamp"].to_f
+      data["@timestamp_f"] = data["@timestamp"].to_f
+      data.remove("@timestamp")
       @buffer << data.to_hash
     end
   end # def encode


### PR DESCRIPTION
Timestamp needs to be a time object. So, we'll just use a different variable to hold the float timestamp until we decode it later. 
