### PR TITLE
Add varnish-rb gem to dependencies

### DIFF
--- a/logstash-contrib.gemspec
+++ b/logstash-contrib.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "rsolr"                            #(Apache 2.0 license)
   gem.add_runtime_dependency "jmx4r"                            #(Apache 2.0 license)
   gem.add_runtime_dependency "fog", ["1.20.0"]                 #(MIT license)
+  gem.add_runtime_dependency "varnish-rb"                       #(MIT license)
 
   if RUBY_PLATFORM == 'java'
     gem.platform = RUBY_PLATFORM


### PR DESCRIPTION
varnish-rb gem is required for varnish input.
Closes #44
