### PR TITLE
Incorrect example on match field of grep filter

### DIFF
--- a/lib/logstash/filters/grep.rb
+++ b/lib/logstash/filters/grep.rb
@@ -35,7 +35,7 @@ class LogStash::Filters::Grep < LogStash::Filters::Base
   #
   #     filter {
   #       grep {
-  #         match => [ "message", "hello world" ]
+  #         match => { "message" => "hello world" }
   #       }
   #     }
   #


### PR DESCRIPTION
Fixed example on match field of grep filter.
