### PR TITLE
new plugin : aggregate filter

### DIFF
--- a/lib/logstash/filters/aggregate.rb
+++ b/lib/logstash/filters/aggregate.rb
@@ -1,0 +1,207 @@
+# aggregate filter
+
+require "logstash/filters/base"
+require "logstash/namespace"
+require "thread"
+
+#
+# The aim of this filter is to aggregate informations available among several events (typically log lines) belonging to a same task,
+# and finally push aggregated information into final task event.
+# 
+# To do that :
+# - the filter needs a "task_id" to correlate events (log lines) of a same task
+# - at the task beggining, filter creates a map, attached to task_id
+# - for each event, you can execute code using 'event' and 'map' (for instance, copy an event field to map)
+# - in the final event, you can execute a last code (for instance, add map data to final event)
+# - after the final event, the map attached to task is deleted
+# - in one filter configuration, it is recommanded to define a timeout option to protect the feature against unterminated tasks. It tells the filter to delete expired maps
+# - if no timeout is defined, by default, all maps older than 1800 seconds are automatically deleted
+
+# An example of use can be:
+# * with this given data : 
+#     INFO - 12345 - TASK_START - start message
+#     INFO - 12345 - DAO - MyDao.findById - 12
+#     INFO - 12345 - DAO - MyDao.findAll - 34
+#     INFO - 12345 - TASK_END - end message
+#
+# * you can aggregate "dao duration" with this configuration : 
+
+#     filter {
+#         grok {
+#             match => [ "message", "%{SPACE}%{LOGLEVEL:loglevel} - %{NOTSPACE:requestid} - %{NOTSPACE:logger} - %{GREEDYDATA:msg}(\n%{GREEDYDATA})?" ]
+#         }
+#     
+#         if [logger] == "TASK_START" {
+#             aggregate {
+#                 task_id => "%{requestid}"
+#                 code => "map['dao.duration'] = 0"
+#                 map_action => "create"
+#             }
+#         }
+#     
+#         if [logger] == "DAO" {
+#             grok {
+#                 match => [ "msg", "%{JAVACLASS:dao_call} - %{INT:duration:int}" ]
+#             }
+#             aggregate {
+#                 task_id => "%{requestid}"
+#                 code => "map['dao.duration'] += event['duration']"
+#                 map_action => "update"
+#             }
+#         }
+#     
+#         if [logger] == "TASK_END" {
+#             aggregate {
+#                 task_id => "%{requestid}"
+#                 code => "event.to_hash.merge!(map)"
+#                 map_action => "update"
+#                 end_of_task => true
+#                 timeout => 120
+#             }
+#         }
+#     }
+
+#
+class LogStash::Filters::Aggregate < LogStash::Filters::Base
+
+	config_name "aggregate"
+	milestone 1
+	
+	# The expression defining task ID to correlate logs.
+	# This value must uniquely identify the task in the system
+	# Example value : "%{application}%{my_task_id}"
+	config :task_id, :validate => :string, :required => true
+
+	# The code to execute to update map, using current event.
+	# You will have a 'map' variable and an 'event' variable available (that is the event itself).
+	config :code, :validate => :string, :required => true
+
+	# Tell the filter what to do with aggregate map (default :  "create_or_update").
+	# create: create the map, and execute the code only if map wasn't created before
+	# update: doesn't create the map, and execute the code only if map was created before
+	# create_or_update: create the map if it wasn't created before, execute the code in all cases
+	config :map_action, :validate => :string, :default => "create_or_update"
+
+	# Tell the filter that task is ended, and therefore, to delete map after code execution.
+	config :end_of_task, :validate => :boolean, :default => false
+
+	# The amount of seconds after an "end event" can be considered lost.
+	# The corresponding "map" is discarded.
+	# The default value is 0, which means no timeout so no auto eviction.
+	config :timeout, :validate => :number, :required => false, :default => 0
+
+	
+	# Default timeout (in seconds) when not defined in plugin configuration
+	DEFAULT_TIMEOUT = 1800
+
+	# This is the state of the filter.
+	# For each entry, key is "task_id" and value is a map freely updatable by 'code' config
+	@@aggregate_maps = {}
+
+	# Mutex used to synchronize access to 'aggregate_maps'
+	@@mutex = Mutex.new
+
+	# Aggregate instance which will evict all zombie Aggregate elements (older than timeout)
+	@@eviction_instance = nil
+
+	# last time where eviction was launched
+	@@last_eviction_timestamp = nil
+
+	# Initialize plugin
+	public
+	def register
+		# process lambda expression to call in each filter call
+		eval("@codeblock = lambda { |event, map| #{@code} }", binding, "(aggregate filter code)")
+
+		# define eviction_instance
+		@@mutex.synchronize do
+			if (@timeout > 0 && (@@eviction_instance.nil? || @timeout < @@eviction_instance.timeout))
+				@@eviction_instance = self
+				@logger.info("Aggregate, timeout: #{@timeout} seconds")
+			end
+		end
+	end
+
+	
+	# This method is invoked each time an event matches the filter
+	public
+	def filter(event)
+		# return nothing unless there's an actual filter event
+		return unless filter?(event)
+
+		# define task id
+		task_id = event.sprintf(@task_id)
+		return if task_id.nil? || task_id.empty? || task_id == @task_id
+
+		@@mutex.synchronize do
+			# retrieve the current aggregate map
+			aggregate_maps_element = @@aggregate_maps[task_id]
+			if (aggregate_maps_element.nil?)
+				return if @map_action == "update"
+				aggregate_maps_element = LogStash::Filters::Aggregate::Element.new(event["@timestamp"]);
+				@@aggregate_maps[task_id] = aggregate_maps_element
+			else
+				return if @map_action == "create"
+			end
+			map = aggregate_maps_element.map
+
+			# execute the code to read/update map and event
+			@codeblock.call(event, map)
+			
+			# delete the map if task is ended
+			@@aggregate_maps.delete(task_id) if @end_of_task
+		end
+
+		filter_matched(event)
+	end
+
+	
+	# This method is invoked by LogStash every 5 seconds.
+	def flush()
+		# Protection against no timeout defined by logstash conf : define a default eviction instance with timeout = DEFAULT_TIMEOUT seconds
+		if (@@eviction_instance.nil?)
+			@@eviction_instance = self
+			@timeout = DEFAULT_TIMEOUT
+		end
+		
+		# Launch eviction only every interval of (@timeout / 2) seconds
+		if (@@eviction_instance == self && (@@last_eviction_timestamp.nil? || Time.now > @@last_eviction_timestamp + @timeout / 2))
+			remove_expired_elements()
+			@@last_eviction_timestamp = Time.now
+		end
+		
+		return nil
+	end
+
+	
+	# Remove the expired Aggregate elements from "aggregate_maps" if they are older than timeout
+	def remove_expired_elements()
+		min_timestamp = Time.now - @timeout
+		@@mutex.synchronize do
+			@@aggregate_maps.delete_if { |key, element| element.creation_timestamp < min_timestamp }
+		end
+	end
+
+	# Getter/Setter methods used for the tests
+	def self.aggregate_maps
+		@@aggregate_maps
+	end
+	def self.eviction_instance
+		@@eviction_instance
+	end
+	def self.set_eviction_instance_nil
+		@@eviction_instance = nil
+	end
+
+end # class LogStash::Filters::Aggregate
+
+# Element of "aggregate_maps"
+class LogStash::Filters::Aggregate::Element
+
+	attr_accessor :creation_timestamp, :map
+
+	def initialize(creation_timestamp)
+		@creation_timestamp = creation_timestamp
+		@map = {}
+	end
+end

--- a/lib/logstash/filters/aggregate.rb
+++ b/lib/logstash/filters/aggregate.rb
@@ -138,7 +138,7 @@ class LogStash::Filters::Aggregate < LogStash::Filters::Base
 			aggregate_maps_element = @@aggregate_maps[task_id]
 			if (aggregate_maps_element.nil?)
 				return if @map_action == "update"
-				aggregate_maps_element = LogStash::Filters::Aggregate::Element.new(event["@timestamp"]);
+				aggregate_maps_element = LogStash::Filters::Aggregate::Element.new(Time.now);
 				@@aggregate_maps[task_id] = aggregate_maps_element
 			else
 				return if @map_action == "create"

--- a/spec/filters/aggregate.rb
+++ b/spec/filters/aggregate.rb
@@ -1,0 +1,199 @@
+require "logstash/filters/aggregate"
+
+describe LogStash::Filters::Aggregate do
+	def event(data = {})
+		data["message"] ||= "Log message"
+		data["@timestamp"] ||= Time.now
+		LogStash::Event.new(data)
+	end
+
+	def start_event(data = {})
+		data["logger"] = "TASK_START"
+		event(data)
+	end
+
+	def update_event(data = {})
+		data["logger"] = "DAO"
+		event(data)
+	end
+
+	def end_event(data = {})
+		data["logger"] = "TASK_END"
+		event(data)
+	end
+
+	def setup_filter(config = {})
+		config["task_id"] ||= "%{requestid}"
+		filter = LogStash::Filters::Aggregate.new(config)
+		filter.register()
+		return filter
+	end
+
+	def aggregate_maps()
+		LogStash::Filters::Aggregate.aggregate_maps
+	end
+
+	def filter(event)
+		@start_filter.filter(event)
+		@update_filter.filter(event)
+		@end_filter.filter(event)
+	end
+
+	before(:each) do
+		LogStash::Filters::Aggregate.set_eviction_instance_nil()
+		aggregate_maps.clear()
+		@start_filter = setup_filter({ "map_action" => "create", "code" => "map['dao.duration'] = 0" })
+		@update_filter = setup_filter({ "map_action" => "update", "code" => "map['dao.duration'] += event['duration']" })
+		@end_filter = setup_filter({ "map_action" => "update", "code" => "event.to_hash.merge!(map)", "end_of_task" => true, "timeout" => 5 })
+	end
+
+	context "Start event" do
+		describe "and receiving an event without task_id" do
+			it "does not record it" do
+				@start_filter.filter(event())
+				insist { aggregate_maps.size } == 0
+			end
+		end
+		describe "and receiving an event with task_id" do
+			it "records it" do
+				event = start_event("requestid" => "id123")
+				@start_filter.filter(event)
+
+				insist { aggregate_maps.size } == 1
+				insist { aggregate_maps["id123"].nil? } == false
+				insist { aggregate_maps["id123"].creation_timestamp } == event["@timestamp"]
+				insist { aggregate_maps["id123"].map["dao.duration"] } == 0
+			end
+		end
+
+		describe "and receiving two 'start events' for the same task_id" do
+			it "keeps the first one and does nothing with the second one" do
+				first_start_event = start_event("requestid" => "id124")
+				first_update_event = update_event("requestid" => "id124", "duration" => 2)
+				second_start_event = start_event("requestid" => "id124")
+
+				@start_filter.filter(first_start_event)
+				@update_filter.filter(first_update_event)
+				sleep(1)
+				@start_filter.filter(second_start_event)
+
+				insist { aggregate_maps.size } == 1
+				insist { aggregate_maps["id124"].creation_timestamp } == first_start_event["@timestamp"]
+				insist { aggregate_maps["id124"].map["dao.duration"] } == first_update_event["duration"]
+			end
+		end
+	end
+
+	context "End event" do
+		describe "receiving an event without a previous 'start event'" do
+			describe "but without a previous 'start event'" do
+				it "does nothing with the event" do
+					end_event = end_event("requestid" => "id124")
+					@end_filter.filter(end_event)
+
+					insist { aggregate_maps.size } == 0
+					insist { end_event["dao.duration"].nil? } == true
+				end
+			end
+		end
+	end
+
+	context "Start/end events interaction" do
+		describe "receiving a 'start event'" do
+			before(:each) do
+				@task_id_value = "id_123"
+				@start_event = start_event({"requestid" => @task_id_value})
+				@start_filter.filter(@start_event)
+				insist { aggregate_maps.size } == 1
+			end
+
+			describe "and receiving an end event" do
+				describe "and without an id" do
+					it "does nothing" do
+						end_event = end_event()
+						@end_filter.filter(end_event)
+						insist { aggregate_maps.size } == 1
+						insist { end_event["dao.duration"].nil? } == true
+					end
+				end
+
+				describe "and an id different from the one of the 'start event'" do
+					it "does nothing" do
+						different_id_value = @task_id_value + "_different"
+						@end_filter.filter(end_event("requestid" => different_id_value))
+
+						insist { aggregate_maps.size } == 1
+						insist { aggregate_maps[@task_id_value].creation_timestamp } == @start_event["@timestamp"]
+					end
+				end
+
+				describe "and the same id of the 'start event'" do
+					it "add 'dao.duration' field to the end event and deletes the recorded 'start event'" do
+						insist { aggregate_maps.size } == 1
+
+						@update_filter.filter(update_event("requestid" => @task_id_value, "duration" => 2))
+
+						end_event = end_event("requestid" => @task_id_value)
+						@end_filter.filter(end_event)
+
+						insist { aggregate_maps.size } == 0
+						insist { end_event["dao.duration"] } == 2
+					end
+
+				end
+			end
+		end
+	end
+
+	context "flush call" do
+		before(:each) do
+			@end_filter.timeout = 1
+			insist { @end_filter.timeout } == 1
+			@task_id_value = "id_123"
+			@start_event = start_event({"requestid" => @task_id_value})
+			@start_filter.filter(@start_event)
+			insist { aggregate_maps.size } == 1
+		end
+
+		describe "no timeout defined in none filter" do
+			it "defines a default timeout on a default filter" do
+				LogStash::Filters::Aggregate.set_eviction_instance_nil()
+				insist { LogStash::Filters::Aggregate.eviction_instance.nil? } == true
+				@end_filter.flush()
+				insist { LogStash::Filters::Aggregate.eviction_instance } == @end_filter
+				insist { @end_filter.timeout } == LogStash::Filters::Aggregate::DEFAULT_TIMEOUT
+			end
+		end
+
+		describe "timeout is defined on another filter" do
+			it "eviction_instance is not updated" do
+				insist { LogStash::Filters::Aggregate.eviction_instance.nil? } == false
+				@start_filter.flush()
+				insist { LogStash::Filters::Aggregate.eviction_instance } != @start_filter
+				insist { LogStash::Filters::Aggregate.eviction_instance } == @end_filter
+			end
+		end
+
+		describe "no timeout defined on the filter" do
+			it "event is not removed" do
+				sleep(2)
+				@start_filter.flush()
+				insist { aggregate_maps.size } == 1
+			end
+		end
+
+		describe "timeout defined on the filter" do
+			it "event is not removed if not expired" do
+				@end_filter.flush()
+				insist { aggregate_maps.size } == 1
+			end
+			it "event is removed if expired" do
+				sleep(2)
+				@end_filter.flush()
+				insist { aggregate_maps.size } == 0
+			end
+		end
+
+	end
+
+end


### PR DESCRIPTION
**New plugin : aggregate filter**

*This pull request is linked to this jira issue :*
https://logstash.jira.com/browse/LOGSTASH-2194

 The aim of this filter is to aggregate informations available among several events (typically log lines) belonging to a same task,
 and finally push aggregated information into final task event.
 
 To do that :
- the filter needs a "task_id" to correlate events (log lines) of a same task
- at the task beggining, filter creates a map, attached to task_id
- for each event, you can execute code using 'event' and 'map' (for instance, copy an event field to map)
- in the final event, you can execute a last code (for instance, add map data to final event)
- after the final event, the map attached to task is deleted
- in one filter configuration, it is recommanded to define a timeout option to protect the feature against unterminated tasks. It tells the filter to delete expired maps
- if no timeout is defined, by default, all maps older than 1800 seconds are automatically deleted

 An example of use can be:
 * with this given data : 
```
     INFO - 12345 - TASK_START - start message
     INFO - 12345 - DAO - MyDao.findById - 12
     INFO - 12345 - DAO - MyDao.findAll - 34
     INFO - 12345 - TASK_END - end message
```
 * you can aggregate "dao duration" with this configuration : 
``` ruby
     filter {
         grok {
             match => [ "message", "%{SPACE}%{LOGLEVEL:loglevel} - %{NOTSPACE:requestid} - %{NOTSPACE:logger} - %{GREEDYDATA:msg}(\n%{GREEDYDATA})?" ]
         }
     
         if [logger] == "TASK_START" {
             aggregate {
                 task_id => "%{requestid}"
                 code => "map['dao.duration'] = 0"
                 map_action => "create"
             }
         }
     
         if [logger] == "DAO" {
             grok {
                 match => [ "msg", "%{JAVACLASS:dao_call} - %{INT:duration:int}" ]
             }
             aggregate {
                 task_id => "%{requestid}"
                 code => "map['dao.duration'] += event['duration']"
                 map_action => "update"
             }
         }
     
         if [logger] == "TASK_END" {
             aggregate {
                 task_id => "%{requestid}"
                 code => "event.to_hash.merge!(map)"
                 map_action => "update"
                 end_of_task => true
                 timeout => 120
             }
         }
     }
```
