### PR TITLE
adds varnishncsa input

### DIFF
--- a/lib/logstash/inputs/varnishncsa.rb
+++ b/lib/logstash/inputs/varnishncsa.rb
@@ -1,0 +1,83 @@
+# encoding: utf-8
+require "logstash/inputs/base"
+require "logstash/namespace"
+require "socket" # for Socket.gethostname
+
+# Stream Varnish logs in Apache / NCSA combined log format
+# https://www.varnish-cache.org/docs/3.0/reference/varnishncsa.html
+class LogStash::Inputs::Varnishncsa < LogStash::Inputs::Base
+  DEFAULT_FORMAT =
+  '{"@timestamp":"%{%Y-%m-%dT%H:%M:%S%z}t","request_url":"%U","response_time_microseconds":"%D",
+  "response_time_seconds":"%T","request_protocol":"%H","response_size":"%b",
+  "request_method":"%m","query_string":"%q","message":"%r","status":"%s","http_user":"%u",
+  "request_header_x_forwarded_for":"%{X-Forwarded-For}i","request_header_user_agent":"%{User-agent}i",
+  "request_header_accept_language":"%{Accept-Language}i","request_header_host":"%{Host}i","request_header_referer":"%{Referer}i",
+  "response_header_cache_control":"%{Cache-Control}o","response_header_content_encoding":"%{Content-Encoding}o",
+  "response_header_content_type":"%{Content-Type}o","response_header_last_modified":"%{Last-Modified}o",
+  "varnish_time_firstbyte":"%{Varnish:time_firstbyte}x","varnish_hitmiss":"%{Varnish:hitmiss}x",
+  "varnish_handling":"%{Varnish:handling}x"}'
+
+  config_name "varnishncsa"
+  milestone 1
+
+  default :codec, "json"
+
+  # Set the format for varnishncsa
+  #
+  #  'default' will use the following output:
+  #     '{"@timestamp":"%{%Y-%m-%dT%H:%M:%S%z}t","request_url":"%U","response_time_microseconds":"%D",
+  #     "response_time_seconds":"%T","request_protocol":"%H","response_size":"%b",
+  #     "request_method":"%m","query_string":"%q","message":"%r","status":"%s","http_user":"%u",
+  #     "request_header_x_forwarded_for":"%{X-Forwarded-For}i","request_header_user_agent":"%{User-agent}i",
+  #     "request_header_accept_language":"%{Accept-Language}i","request_header_host":"%{Host}i","request_header_referer":"%{Referer}i",
+  #     "response_header_cache_control":"%{Cache-Control}o","response_header_content_encoding":"%{Content-Encoding}o",
+  #     "response_header_content_type":"%{Content-Type}o","response_header_last_modified":"%{Last-Modified}o",
+  #     "varnish_time_firstbyte":"%{Varnish:time_firstbyte}x","varnish_hitmiss":"%{Varnish:hitmiss}x",
+  #     "varnish_handling":"%{Varnish:handling}x"}'
+  #
+  #   or put whatever format you like that suppoted by varnishncsa:
+  #   https://www.varnish-cache.org/docs/3.0/reference/varnishncsa.html
+  #
+  config :format, :validate => :string, :required => true, :default => 'default'
+  
+  public
+  def register
+    @logger.info("Registering varnishncsa input", :format => @format)
+    @format = case @format
+              when 'default'
+                DEFAULT_FORMAT.gsub(/\n\s/,'')
+              else
+                @format
+              end
+
+    command = "varnishncsa -F '#{@format}'"
+    @pipe = IO.popen(command, mode="r")
+  end # def register
+
+  def teardown
+    @pipe.close if @pipe
+  end
+
+  def run(queue)
+    loop do
+      begin
+        hostname = Socket.gethostname
+        @pipe.each do |line|
+          @codec.decode(line) do |event|
+            event["source_host"] = hostname
+            decorate(event)
+            queue << event
+          end
+        end
+      rescue LogStash::ShutdownSignal => e
+        break
+      rescue Exception => e
+        @logger.error("Exception while running varnishncsa", :e => e, :backtrace => e.backtrace)
+      ensure
+        @pipe.close
+      end
+
+      sleep(1)
+    end
+  end # def run
+end # class LogStash::Inputs::Varnishncsa


### PR DESCRIPTION
this pull request adds a varnishncsa input for simple logging event from Varnish cache.
more info on varnishncsa: 
https://www.varnish-cache.org/docs/3.0/reference/varnishncsa.html

here is an example of log message generated by the plugin:

``` json
{
  "_index": "logstash-2014.06.05",
  "_type": "varnishncsa",
  "_id": "rf2Fz8LUQ66IvD5jA63sXA",
  "_score": null,
  "_source": {
    "@timestamp": "2014-06-05T11:03:53.000+00:00",
    "request_url": "/v12/accounts/105.json",
    "response_time_microseconds": "0.022854",
    "response_time_seconds": "0",
    "request_protocol": "HTTP/1.1",
    "response_size": "3713",
    "request_method": "GET",
    "query_string": "?api[bundle]=com.miteleliteandroid&api[bver]=2.0.30&api[device_model]=SM-G3815&api[os_type]=android&api[os_version]=17&api[sig]=E38DEA0EFC6C83C56CF37C9194BC6E15&api[timestamp]=1401966231&api[udid]=644410ad46d94f13&api[uuid]=533c8d59b",
    "message": "GET http://admin.applicaster.com/v12/accounts/105.json?api[bundle]=com.miteleliteandroid&api[bver]=2.0.30&api[device_model]=SM-G3815&api[os_type]=android&api[os_version]=17&api[sig]=E38DEA0EFC6C83C56CF37C9194BC6E15&api[timestamp]=1401966231&api[udid]=644410ad46d94f13&api[uuid]=533c8d59b HTTP/1.1",
    "status": "200",
    "http_user": "-",
    "request_header_x_forwarded_for": "31.4.181.86",
    "request_header_user_agent": "-",
    "request_header_accept_language": "-",
    "request_header_host": "admin.applicaster.com",
    "request_header_referer": "-",
    "response_header_cache_control": "max-age=0, private, must-revalidate",
    "response_header_content_encoding": "-",
    "response_header_content_type": "application/json; charset=utf-8",
    "response_header_last_modified": "-",
    "varnish_time_firstbyte": "0.022815943",
    "varnish_hitmiss": "miss",
    "varnish_handling": "pass",
    "@version": "1",
    "source_host": "ip-10-140-168-41",
    "type": "varnishncsa",
    "tags": [
      "applicaster2"
    ]
  }
```
