### PR TITLE
Remove require to racob_fix

### DIFF
--- a/lib/logstash/inputs/wmi.rb
+++ b/lib/logstash/inputs/wmi.rb
@@ -37,8 +37,6 @@ class LogStash::Inputs::WMI < LogStash::Inputs::Base
     @logger.info("Registering wmi input", :query => @query)
 
     if RUBY_PLATFORM == "java"
-      # make use of the same fix used for the eventlog input
-      require "logstash/inputs/eventlog/racob_fix"
       require "jruby-win32ole"
     else
       require "win32ole"


### PR DESCRIPTION
Since 1.4.x is not using jar packaging, the special fix to load racob_dll is not required and was removed from logstash-core. Eventlog input was updated but not this one.
Fix for #68
