### PR TITLE
WMI filter

### DIFF
--- a/lib/logstash/filters/wmi.rb
+++ b/lib/logstash/filters/wmi.rb
@@ -59,7 +59,7 @@ class LogStash::Filters::Wmi < LogStash::Filters::Base
   def filter(event)
     return unless filter?(event)
 
-	@wmi = WIN32OLE.connect("winmgmts://")
+    @wmi = WIN32OLE.connect("winmgmts://")
 
     @logger.debug("Running wmi filter", :event => event)
 
@@ -71,10 +71,10 @@ class LogStash::Filters::Wmi < LogStash::Filters::Base
     end
 
     begin
-	  @query = event.sprintf(@query)
-	  @logger.debug("Executing WMI query '#{@query}'")
+	  actualQuery = event.sprintf(@query)
+	  @logger.debug("Executing WMI query '#{actualQuery}'")
 
-	  @wmi.ExecQuery(@query).each do |wmiobj|
+	  @wmi.ExecQuery(actualQuery).each do |wmiobj|
 	      wmiobj.Properties_.each do |prop|
             dest[prop.name] = prop.value
           end

--- a/lib/logstash/filters/wmi.rb
+++ b/lib/logstash/filters/wmi.rb
@@ -1,0 +1,94 @@
+# encoding: utf-8
+require "logstash/filters/base"
+require "logstash/namespace"
+
+# This is a WMI query filter. It adds the executed wmi query result properties to the current event
+class LogStash::Filters::Wmi < LogStash::Filters::Base
+
+  config_name "wmi"
+  milestone 2
+
+  # The configuration for the wmi filter:
+  #
+  # Example:
+  #
+  #     input {
+  #       wmi {
+  #         query => "select * from Win32_Process"
+  #       }
+  #       wmi {
+  #         query => "select PercentProcessorTime from Win32_PerfFormattedData_PerfOS_Processor where name = '_Total'"
+  #       }
+  #     }
+
+  # Define the target field for placing the wmi query data. If this setting is
+  # omitted, the WMI data will be stored at the root (top level) of the event.
+  #
+  # For example, if you want the data to be put in the 'doc' field:
+  #
+  #     filter {
+  #       wsi {
+  #         target => "doc"
+  #       }
+  #     }
+  #
+  #
+  # NOTE: if the `target` field already exists, it will be overwritten!
+
+  # WMI query
+  config :query, :validate => :string, :required => true
+  # optional target
+  config :target, :validate => :string
+
+
+  TIMESTAMP = "@timestamp"
+
+  public
+  def register
+
+    @logger.info("Registering wmi filter", :query => @query)
+
+    if RUBY_PLATFORM == "java"
+      require "jruby-win32ole"
+    else
+      require "win32ole"
+    end
+  end # def register
+
+  public
+  def filter(event)
+    return unless filter?(event)
+
+	@wmi = WIN32OLE.connect("winmgmts://")
+
+    @logger.debug("Running wmi filter", :event => event)
+
+    if @target.nil?
+      # Default is to write to the root of the event.
+      dest = event.to_hash
+    else
+        dest = event[@target] ||= {}
+    end
+
+    begin
+	  @query = event.sprintf(@query)
+	  @logger.debug("Executing WMI query '#{@query}'")
+
+	  @wmi.ExecQuery(@query).each do |wmiobj|
+	      wmiobj.Properties_.each do |prop|
+            dest[prop.name] = prop.value
+          end
+	  end
+
+      filter_matched(event)
+    rescue => e
+      event.tag("_wmifailure")
+      @logger.warn("Trouble executing wmi query", :exception => e)
+      return
+    end
+
+    @logger.debug("Event after wmi filter", :event => event)
+
+  end # def filter
+
+end # class LogStash::Filters::Wmi


### PR DESCRIPTION
A WMI filter that adds the results from a WMI query to the current event. An optional target destination may be specified. If omitted, the fields will be added to the root event.

This filter is useful for performing join operations between different WMI "tables".

For example, suppose we want to create an event that displays the command line arguments of some process (WIN32_Process) and show the memory consumption of that process (Win32_PerfFormattedData_PerfProc_Process). 

This data resides in the two mentioned WMI tables, with the ProcessId (or IDProcess) being the primary key of those tables. 

Using such a filter we can do the following:

input
{
    wmi
    {
        query => "Select processid, name, commandline From Win32_Process  where name = 'w3wp.exe'  "
        interval => 1
        type => "perfmem"
    }
}

filter
{
    wmi
    {
        query => "Select privatebytes, workingsetprivate, threadcount From Win32_PerfFormattedData_PerfProc_Process where IDProcess = %{ProcessId}"
    }

```
mutate
{
    convert =>
    [
        "privatebytes", "integer",
            "workingsetprivate", "integer"
    ]
}
```

}

output
{
    stdout { codec => "rubydebug" }
}

This filter was inspired by the json filter and wmi input. It uses the "target" field to specify a destination for the new fields just like the json filter, and it uses the wmi input logic to perform wmi queries exactly the same way.
