### PR TITLE
Fixes map_fields behaviour in riemann output plugin

### DIFF
--- a/lib/logstash/outputs/riemann.rb
+++ b/lib/logstash/outputs/riemann.rb
@@ -140,7 +140,7 @@ class LogStash::Outputs::Riemann < LogStash::Outputs::Base
     end
     if @map_fields == true
       @my_event = Hash.new
-      map_fields(nil, event)
+      map_fields(nil, event.to_hash)
       r_event.merge!(@my_event) {|key, val1, val2| val1}
     end
     r_event[:tags] = event["tags"] if event["tags"].is_a?(Array)


### PR DESCRIPTION
Currently, the riemann output plugin will crash with the `map_fields` option set to `true`. This is a proposed fix.
