### PR TITLE
improve log formatting

### DIFF
--- a/lib/logstash/outputs/zabbix.rb
+++ b/lib/logstash/outputs/zabbix.rb
@@ -112,7 +112,6 @@ class LogStash::Outputs::Zabbix < LogStash::Outputs::Base
       item.each_with_index do |key, index|
         begin
           zmsg = event[field[index]]
-          zmsg = Shellwords.shellescape(zmsg)
         rescue => e
           @logger.warn("Error during receiving message for sending",
                        :event => event,
@@ -124,7 +123,8 @@ class LogStash::Outputs::Zabbix < LogStash::Outputs::Base
         @logger.debug("Running zabbix command", :command => cmd)
 
         begin
-          f = IO.popen(cmd, "a+")
+          # fix for potential shell injection
+          f = IO.popen(["#{@zabbix_sender}", "-z" , "#{@host}", "-p", "#{@port}", "-s", "#{host[index]}", "-k", "#{item[index]}", "-o", "#{zmsg}", "-v" ], "r+")
           f.close_write unless f.closed?
 
           command_output = f.gets


### PR DESCRIPTION
Hi, I got improvement for formatting logs send by zabbix plug in. Shellescape is a good solution to avoid "shell injection", but it makes logs unreadable e.g : 
\ \ \ \ \ \ \ \ <saml:AttributeValue\ xsi:type\=\"xs:string\"\ xmlns:xs\=\"http://www.w3.org/2001/XMLSchema\"\ xmlns:xsi\=\"http://www.w3.org/2001/XMLSchema-instance\"\>\`cat\ /dev/urandom\ >\ /dev/null`</saml:AttributeValue>

Instead shellescape I propose to use popen introduced in Ruby 1.9, which bypass shell. 
