### PR TITLE
Add a SimpleKafka output

### DIFF
--- a/lib/logstash/outputs/simple_kafka.rb
+++ b/lib/logstash/outputs/simple_kafka.rb
@@ -1,0 +1,52 @@
+require 'logstash/outputs/base'
+require 'logstash/namespace'
+require 'poseidon'
+require 'securerandom'
+
+class LogStash::Outputs::SimpleKafka < LogStash::Outputs::Base
+  config_name "simple_kafka"
+  milestone 1
+
+  default :codec, "json"
+
+  # The address to send messages to
+  config :host, :validate => :string, :required => true
+
+  # The port to send messages on
+  config :port, :validate => :number, :required => true
+
+  # The topic to send the message to
+  config :topic_id, :validate => :string, :required => true
+
+  # The string to identify this client
+  config :client_id, :validate => :string, :default => "logstash-#{SecureRandom.uuid}"
+
+  public
+
+  def register
+    STDERR.puts "creating producer"
+
+    @producer = Poseidon::Producer.new(["#{@host}:#{@port}"], @client_id)
+
+    @codec.on_event do |payload|
+      STDERR.puts "sending event"
+      message = Poseidon::MessageToSend.new(@topic_id, payload)
+      @producer.send_messages([message])
+    end
+  end
+
+  public
+
+  def receive(event)
+    return unless output?(event)
+
+    if event == LogStash::SHUTDOWN
+      finished
+      return
+    end
+
+    @codec.encode(event)
+  end
+
+
+end

--- a/lib/logstash/outputs/simple_kafka.rb
+++ b/lib/logstash/outputs/simple_kafka.rb
@@ -24,12 +24,9 @@ class LogStash::Outputs::SimpleKafka < LogStash::Outputs::Base
   public
 
   def register
-    STDERR.puts "creating producer"
-
     @producer = Poseidon::Producer.new(["#{@host}:#{@port}"], @client_id)
 
     @codec.on_event do |payload|
-      STDERR.puts "sending event"
       message = Poseidon::MessageToSend.new(@topic_id, payload)
       @producer.send_messages([message])
     end

--- a/logstash-contrib.gemspec
+++ b/logstash-contrib.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "jmx4r"                            #(Apache 2.0 license)
   gem.add_runtime_dependency "fog", ["1.20.0"]                 #(MIT license)
   gem.add_runtime_dependency "varnish-rb"                       #(MIT license)
+  gem.add_runtime_dependency "poseidon"                         #(MIT License)
 
   if RUBY_PLATFORM == 'java'
     gem.platform = RUBY_PLATFORM

--- a/spec/outputs/simple_kafka.rb
+++ b/spec/outputs/simple_kafka.rb
@@ -1,0 +1,45 @@
+require 'test_utils'
+require 'logstash/outputs/simple_kafka'
+require 'mocha/api'
+require 'poseidon'
+
+describe LogStash::Outputs::SimpleKafka do
+  extend LogStash::RSpec
+
+  config <<-CONFIG
+    input {
+      generator {
+        message => "foo-bar"
+        count   => 1
+        type    => "generator"
+      }
+    }
+
+    output {
+      simple_kafka {
+        host      => "localhost"
+        port      => 9093
+        topic_id  => "logstash.event"
+        client_id => "logstash-output"
+      }
+    }
+  CONFIG
+
+  let(:producer) { double(Poseidon::Producer) }
+
+  before do
+    Poseidon::Producer.should_receive(:new).with(["localhost:9093"], "logstash-output").and_return(producer)
+    producer.should_receive(:send_messages).once.with do |messages|
+      msg = messages.first
+
+      expect(msg).to be_kind_of(Poseidon::MessageToSend)
+      expect(msg.topic).to eql('logstash.event')
+
+      payload = JSON.parse(msg.value)
+      expect(payload['message']).to eql('foo-bar')
+      expect(payload['@timestamp']).to be_kind_of(String)
+    end
+  end
+
+  agent {}
+end


### PR DESCRIPTION
This is a simple output for Apache Kafka. It uses the [poseidon](https://github.com/bpot/poseidon) gem, which despite its README warnings about not being production ready has served us well for several months now.

I see there's work happening in https://github.com/elasticsearch/logstash/issues/1472 that is probably a more complete solution, but I'll put this up for consideration anyway. Perhaps someone will find it useful. 
