### PR TITLE
Fix bug in collate plugin where tags is called as function

### DIFF
--- a/lib/logstash/filters/collate.rb
+++ b/lib/logstash/filters/collate.rb
@@ -60,7 +60,7 @@ class LogStash::Filters::Collate < LogStash::Filters::Base
     end
 
     # if the event is collated, a "collated" tag will be marked, so for those uncollated event, cancel them first.
-    if event["tags"].nil? || !event.tags.include?("collated")
+    if event["tags"].nil? || !event["tags"].include?("collated")
       event.cancel
     else
       return


### PR DESCRIPTION
If an event going into collate plugin has tags it will encounter a bug because the tags is called as a function of the event instead of an hash key. If the event has no tags this bug doesn't trigger.