### PR TITLE
Lazy Elapsed filter

### DIFF
--- a/lib/logstash/filters/lazyelapsed.rb
+++ b/lib/logstash/filters/lazyelapsed.rb
@@ -44,26 +44,26 @@
 # An example of configuration can be:
 #
 #   filter {
-#   grok {
-#     match => ["message", "%{TIMESTAMP_ISO8601} START id: (?<task_id>.*)"]
-#     add_tag => [ "event_start" ]
-#   }
+#     grok {
+#       match => ["message", "%{TIMESTAMP_ISO8601} START id: (?<task_id>.*)"]
+#       add_tag => [ "event_start" ]
+#     }
 #
-#   grok {
-#     match => ["message", "%{TIMESTAMP_ISO8601} END id: (?<task_id>.*)"]
-#     add_tag => [ "event_end"]
-#   }
+#     grok {
+#       match => ["message", "%{TIMESTAMP_ISO8601} END id: (?<task_id>.*)"]
+#       add_tag => [ "event_end"]
+#     }
 #
-#   grok {
-#     match => ["message", "%{TIMESTAMP_ISO8601} OTHEREND id: (?<task_id>.*)"]
-#     add_tag => [ "event_end"]
-#   }
+#     grok {
+#       match => ["message", "%{TIMESTAMP_ISO8601} OTHEREND id: (?<task_id>.*)"]
+#       add_tag => [ "event_end"]
+#     }
 #
-##   lazyelapsed {
-#     start_tag => "event_start"
-#     end_tag => "event_end"
-#     unique_id_field => "task_id"
-#     timestamp_field => "@timestamp"
+##    lazyelapsed {
+#       start_tag => "event_start"
+#       end_tag => "event_end"
+#       unique_id_field => "task_id"
+#       timestamp_field => "@timestamp"
 #     }
 #   }
 #
@@ -146,6 +146,7 @@ class LogStash::Filters::LazyElapsed < LogStash::Filters::Base
           end
         else
           # End event with no start. Just ignore.
+          @logger.debug("LazyElapsed: End event with no start. Ignoring the event.")
         end
       end
     end
@@ -176,6 +177,7 @@ class LogStash::Filters::LazyElapsed < LogStash::Filters::Base
                 start_time = Time.parse(element.start[@timestamp_field])
               rescue
                 start_time = Time.now # Set it to something?
+                @logger.debug("LazyElapsed: Couldn't parse timestamp string. Setting start_time to now.")
               end
             end
 
@@ -186,6 +188,7 @@ class LogStash::Filters::LazyElapsed < LogStash::Filters::Base
                 end_time = Time.parse(element.end[@timestamp_field])
               rescue
                 end_time = start_time # Will result in an 0 if we can't parse end time.
+                @logger.debug("LazyElapsed: Couldn't parse timestamp string. Setting end_time to start_time.")
               end
             end
 

--- a/lib/logstash/filters/lazyelapsed.rb
+++ b/lib/logstash/filters/lazyelapsed.rb
@@ -1,0 +1,254 @@
+# encoding: utf-8
+
+# LazyElapsed filter
+#
+# This filter is based on the elapsed filter. The difference is, it tracks a start event and multiple
+# end events. It will continue to look for an end event until the time_to_wait is hit, at which point it 
+# will take the last end event it saw. It generates a new event with the specifed tag_on_match tag as 
+# well as an elapsed time in milliseconds in the elapsed_time field. 
+#
+# If the time_to_wait is hit without finding an end event, an error event is generated with the specified
+# tag_on_error tag.
+#
+# If fields_to_copy_from_start or fields_to_copy_from_end are used, the specified fields will be copied 
+# from either the start event or the end event to the generated event. If the generated event is an error, 
+# only the fields from the start event are copied as there was no end event found. The fields are copied from
+# the start event first and then from the end event. So, if the same field is specified by both
+# fields_to_copy_from_start and fields_to_copy_from_end, the field will end up with the value from 
+# the end event. 
+#
+# LazyElapsed supports some simple aggregation over the events it sees. The fields_to_record will group
+# up the values of a field from all the events seen for a given unique id and will add it to the 
+# generated event using the key of the hash value as the field name. fields_to_sum will do the same thing
+# but will add up the values of the fields.
+#
+# The configuration looks like this:
+#
+# filter {
+#   lazyelapsed {
+#     start_tag => "event_start"
+#     end_tag => "event_end"
+#     tag_on_match => "matched_tag"
+#     tag_on_error => "error_tag"
+#     unique_id_field => "id field name"
+#     timestamp_field => "@timestamp"
+#     time_to_wait => seconds
+#     fields_to_copy_from_start => ["some_field"]
+#     fields_to_copy_from_end => ["another_field","another_field2"]
+#     fields_to_record => {"my_fields" => "my_field"}
+#     fields_to_sum => {"total_server_time" => "server_time"}
+#   }
+# }
+#
+# You can use a Grok filter to prepare the events for the lazyelapsed filter.
+# An example of configuration can be:
+#
+#   filter {
+#   grok {
+#     match => ["message", "%{TIMESTAMP_ISO8601} START id: (?<task_id>.*)"]
+#     add_tag => [ "event_start" ]
+#   }
+#
+#   grok {
+#     match => ["message", "%{TIMESTAMP_ISO8601} END id: (?<task_id>.*)"]
+#     add_tag => [ "event_end"]
+#   }
+#
+#   grok {
+#     match => ["message", "%{TIMESTAMP_ISO8601} OTHEREND id: (?<task_id>.*)"]
+#     add_tag => [ "event_end"]
+#   }
+#
+##   lazyelapsed {
+#     start_tag => "event_start"
+#     end_tag => "event_end"
+#     unique_id_field => "task_id"
+#     timestamp_field => "@timestamp"
+#     }
+#   }
+#
+
+require "logstash/filters/base"
+require "logstash/namespace"
+require 'thread'
+
+class LogStash::Filters::LazyElapsed < LogStash::Filters::Base
+  config_name "lazyelapsed"
+  milestone 1
+
+  config :start_tag, :validate => :string, :required => true
+  config :end_tag, :validate => :string, :required => true
+  config :tag_on_match, :validate => :string, :required => false, :default => "lazy_elapsed_match"
+  config :tag_on_error, :validate => :string, :required => false, :default => "lazy_elapsed_error"
+  config :unique_id_field, :validate => :string, :required => true
+  config :timestamp_field, :validate => :string, :required => true
+  config :time_to_wait, :validate => :number, :required => false, :default => 1800
+  config :fields_to_copy_from_start, :validate => :array, :required => false, :default => []
+  config :fields_to_copy_from_end, :validate => :array, :required => false, :default => []
+  config :fields_to_record, :validate => :hash, :required => false, :default => {} 
+  config :fields_to_sum, :validate => :hash, :required => false, :default => {} 
+
+  public
+  def register
+    @mutex = Mutex.new
+    @start_events = {}
+    @last_new_event = nil
+    @logger.debug("LazyElapsed: registered")
+  end
+
+  # Accessors for testing
+  def start_events
+    @start_events
+  end
+
+  def last_new_event
+    @last_new_event
+  end
+
+  # Respond to an event  
+  def filter(event)
+    return unless filter?(event)
+
+    unique_id = event[@unique_id_field]
+    return if unique_id.nil?
+
+    if(start_event?(event))
+      filter_matched(event)
+      @logger.debug("LazyElapsed: Start event matched")
+      @mutex.synchronize do
+        unless(@start_events.has_key?(unique_id))
+          new_element = LogStash::Filters::LazyElapsed::Element.new(event)
+          @fields_to_sum.each_pair do |key, field|
+            new_element.fields[key] = event[field] if event.include?(field)
+          end
+          @fields_to_record.each_pair do |key, field|
+            if (event.include?(field))
+              new_element.fields[key] = []
+              new_element.fields[key] << event[field]
+            end
+          end
+          @start_events[unique_id] = new_element
+        end
+      end
+
+    elsif(end_event?(event))
+      filter_matched(event)
+      @logger.debug("LazyElapsed: End event matched")
+      @mutex.synchronize do
+        if (@start_events.has_key?(unique_id))
+          element = @start_events[unique_id]
+          element.end = event
+          @fields_to_sum.each_pair do |key, field|
+            element.fields[key] = element.fields[key] + event[field] if event.include?(field)
+          end
+          @fields_to_record.each_pair do |key, field|
+            element.fields[key] << event[field] if event.include?(field)
+          end
+        else
+          # End event with no start. Just ignore.
+        end
+      end
+    end
+  end 
+
+  # The method is invoked by LogStash every 5 seconds.
+  def flush
+    events = []
+    @mutex.synchronize do
+      keys_to_delete = []
+      @start_events.each_pair do |key, element|
+        element.age += 5
+        if (element.age >= @time_to_wait)
+          @logger.debug("LazyElapsed: Time to wait expired for event.")
+
+          if (element.end)
+            # We are at the timeout and have an end element. Create the new event.
+            @logger.debug("LazyElapsed: End event found. Generating elapsed event.")
+            new_event = LogStash::Event.new
+            new_event.tag(@tag_on_match)
+            new_event[@unique_id_field] = element.start[@unique_id_field]
+
+            # Support both a Time timestamp and a string for a timestamp.
+            if element.start[@timestamp_field].is_a?(Time) 
+              start_time = element.start[@timestamp_field]
+            else
+              begin 
+                start_time = Time.parse(element.start[@timestamp_field])
+              rescue
+                start_time = Time.now # Set it to something?
+              end
+            end
+
+            if element.end[@timestamp_field].is_a?(Time) 
+              end_time = element.end[@timestamp_field]
+            else
+              begin 
+                end_time = Time.parse(element.end[@timestamp_field])
+              rescue
+                end_time = start_time # Will result in an 0 if we can't parse end time.
+              end
+            end
+
+            new_event["elapsed_time"] = ((end_time - start_time) * 1000).to_i
+
+            new_event[@timestamp_field] = element.start[@timestamp_field]
+            @fields_to_record.keys.each do |key|
+              new_event[key] = element.fields[key] if element.fields.include?(key)
+            end
+            @fields_to_sum.keys.each do |key|
+              new_event[key] = element.fields[key] if element.fields.include?(key)
+            end
+            @fields_to_copy_from_start.each do |key|
+              new_event[key] = element.start[key] if element.start.include?(key)
+            end
+            @fields_to_copy_from_end.each do |key|
+              new_event[key] = element.end[key] if element.end.include?(key)
+            end
+            @last_new_event = new_event
+            events << new_event
+
+          else
+            # We reached the timeout without an end element. Create an error event.
+            @logger.debug("LazyElapsed: End event not found. Generating error event.")
+            error_event = LogStash::Event.new
+            error_event.tag(@tag_on_error)
+            error_event[@unique_id_field] = element.start[@unique_id_field]
+            error_event[@timestamp_field] = element.start[@timestamp_field]
+            @fields_to_copy_from_start.each do |key|
+              error_event[key] = element.start[key] if element.start.include?(key)
+            end
+            @last_new_event = error_event
+            events << error_event 
+          end
+
+          keys_to_delete << key
+        end
+      end 
+
+      keys_to_delete.each do |key|
+        @start_events.delete(key)
+      end
+    end
+    return events
+  end
+
+  private
+  def start_event?(event)
+    return (event["tags"] != nil && event["tags"].include?(@start_tag))
+  end
+
+  def end_event?(event)
+    return (event["tags"] != nil && event["tags"].include?(@end_tag))
+  end
+end 
+
+class LogStash::Filters::LazyElapsed::Element
+  attr_accessor :start, :end, :age, :fields
+
+  def initialize(start)
+    @start = start
+    @end = nil
+    @age = 0
+    @fields = {}
+  end
+end

--- a/spec/filters/lazyelapsed.rb
+++ b/spec/filters/lazyelapsed.rb
@@ -1,0 +1,508 @@
+# encoding: utf-8
+require 'socket'
+require "logstash/filters/lazyelapsed"
+
+describe LogStash::Filters::LazyElapsed do
+  START_TAG = "event_start"
+  END_TAG   = "event_end"
+  UNIQUE_ID_FIELD  = "unique_id_field"
+
+  it "raises an error if required config isn't there" do
+    # missing timestamp_field.
+    config = {"start_tag" => START_TAG, "end_tag" => END_TAG, "unique_id_field" => UNIQUE_ID_FIELD}
+    expect { LogStash::Filters::LazyElapsed.new(config) }.to raise_error
+
+    # missing unique_id_field.
+    config = {"start_tag" => START_TAG, "end_tag" => END_TAG, "timestamp_field" => "@timestamp"}
+    expect { LogStash::Filters::LazyElapsed.new(config) }.to raise_error
+
+    # missing end_tag.
+    config = {"start_tag" => START_TAG, "unique_id_field" => UNIQUE_ID_FIELD, "timestamp_field" => "@timestamp"}
+    expect { LogStash::Filters::LazyElapsed.new(config) }.to raise_error
+
+    # missing start.
+    config = {"end_tag" => END_TAG, "unique_id_field" => UNIQUE_ID_FIELD, "timestamp_field" => "@timestamp"}
+    expect { LogStash::Filters::LazyElapsed.new(config) }.to raise_error
+  end
+
+
+  it "saves off the start event" do
+    config = {"start_tag" => START_TAG,
+               "end_tag" => END_TAG,
+               "unique_id_field" => UNIQUE_ID_FIELD,
+               "timestamp_field" => "@timestamp"} 
+    filter = LogStash::Filters::LazyElapsed.new(config)
+    filter.register
+  
+    event_data = {
+      "tags" => [ START_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "message" => "some log message"
+    }
+    
+    start_event = LogStash::Event.new(event_data)
+
+    filter.filter(start_event)
+
+    insist { filter.start_events.size } == 1
+    insist { filter.start_events["1"] } != nil 
+    insist { filter.start_events["1"].start } != nil
+    insist { filter.start_events["1"].start["tags"][0] } == START_TAG
+    insist { filter.start_events["1"].start["message"] } == event_data["message"]
+  end
+
+  
+  it "generates a new error event and copies the requested fields from the start event" do
+    config = {"start_tag" => START_TAG,
+               "end_tag" => END_TAG,
+               "unique_id_field" => UNIQUE_ID_FIELD,
+               "timestamp_field" => "@timestamp",
+               "fields_to_copy_from_start" => ["message", "message2"],
+               "time_to_wait" => 2} 
+    filter = LogStash::Filters::LazyElapsed.new(config)
+    filter.register
+  
+    event_data = {
+      "tags" => [ START_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "message" => "some log message",
+      "message2" => "some other log message"
+    }
+    
+    start_event = LogStash::Event.new(event_data)
+
+    filter.filter(start_event)
+    filter.flush()
+  
+    event = filter.last_new_event
+    insist { event } != nil
+    insist { event["tags"][0] } == "lazy_elapsed_error"
+    insist { event["message"] } == event_data["message"]
+    insist { event["message2"] } == event_data["message2"]
+  end
+
+
+  it "does nothing if the field is not there to copy from the start event" do
+    config = {"start_tag" => START_TAG,
+               "end_tag" => END_TAG,
+               "unique_id_field" => UNIQUE_ID_FIELD,
+               "timestamp_field" => "@timestamp",
+               "fields_to_copy_from_start" => ["message3", "message4"],
+               "time_to_wait" => 2} 
+    filter = LogStash::Filters::LazyElapsed.new(config)
+    filter.register
+  
+    event_data = {
+      "tags" => [ START_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "message" => "some log message",
+      "message2" => "some other log message"
+    }
+    
+    start_event = LogStash::Event.new(event_data)
+
+    filter.filter(start_event)
+    filter.flush()
+  
+    event = filter.last_new_event
+    insist { event } != nil
+    insist { event["tags"][0] } == "lazy_elapsed_error"
+    insist { event["message3"] } == nil
+    insist { event["message4"] } == nil
+  end
+
+
+  it "saves the correct end event" do
+    config = {"start_tag" => START_TAG,
+               "end_tag" => END_TAG,
+               "unique_id_field" => UNIQUE_ID_FIELD,
+               "timestamp_field" => "@timestamp",
+               "fields_to_copy_from_start" => ["message3", "message4"],
+               "time_to_wait" => 2} 
+    filter = LogStash::Filters::LazyElapsed.new(config)
+    filter.register
+  
+    start_event_data = {
+      "tags" => [ START_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "message" => "some log message",
+      "message2" => "some other log message"
+    }
+    
+    start_event = LogStash::Event.new(start_event_data)
+
+    end_event_data1 = {
+      "tags" => [ END_TAG ],
+      UNIQUE_ID_FIELD => "2",
+      "message2" => "another extra log message"
+    }
+
+    end_event1 = LogStash::Event.new(end_event_data1)
+
+    end_event_data2 = {
+      "tags" => [ END_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "message3" => "some extra log message"
+    }
+
+    end_event2 = LogStash::Event.new(end_event_data2)
+
+    filter.filter(start_event)
+    filter.filter(end_event1)
+    filter.filter(end_event2)
+
+    insist { filter.start_events["1"].end } != nil
+    insist { filter.start_events["1"].end["tags"][0] } == END_TAG
+    insist { filter.start_events["1"].end["message3"] } == end_event_data2["message3"]
+    insist { filter.start_events["1"].end["message2"] } == nil
+  end
+  
+
+  it "is lazy about the end event to save" do
+    config = {"start_tag" => START_TAG,
+               "end_tag" => END_TAG,
+               "unique_id_field" => UNIQUE_ID_FIELD,
+               "timestamp_field" => "@timestamp",
+               "fields_to_copy_from_start" => ["message3", "message4"],
+               "time_to_wait" => 2} 
+    filter = LogStash::Filters::LazyElapsed.new(config)
+    filter.register
+  
+    start_event_data = {
+      "tags" => [ START_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "message" => "some log message",
+      "message2" => "some other log message"
+    }
+    
+    start_event = LogStash::Event.new(start_event_data)
+
+    end_event_data1 = {
+      "tags" => [ END_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "message3" => "some extra log message"
+    }
+
+    end_event1 = LogStash::Event.new(end_event_data1)
+
+    end_event_data2 = {
+      "tags" => [ END_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "message4" => "This should be the end event we pick"
+    }
+
+    end_event2 = LogStash::Event.new(end_event_data2)
+
+    filter.filter(start_event)
+    filter.filter(end_event1)
+    filter.filter(end_event2)
+
+    insist { filter.start_events["1"].end } != nil
+    insist { filter.start_events["1"].end["tags"][0] } == END_TAG
+    insist { filter.start_events["1"].end["message3"] } == nil
+    insist { filter.start_events["1"].end["message4"] } == end_event_data2["message4"]
+  end
+
+
+  it "generates a new match event and copies the requested fields from the end event" do
+    config = {"start_tag" => START_TAG,
+               "end_tag" => END_TAG,
+               "unique_id_field" => UNIQUE_ID_FIELD,
+               "timestamp_field" => "@timestamp",
+               "fields_to_copy_from_end" => ["message3", "message4"],
+               "time_to_wait" => 2} 
+    filter = LogStash::Filters::LazyElapsed.new(config)
+    filter.register
+  
+    start_event_data = {
+      "tags" => [ START_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "message" => "some log message",
+      "message2" => "some other log message"
+    }
+    
+    start_event = LogStash::Event.new(start_event_data)
+
+    end_event_data = {
+      "tags" => [ END_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "message3" => "some extra log message",
+      "message4" => "another log message"
+    }
+
+    end_event = LogStash::Event.new(end_event_data)
+
+    filter.filter(start_event)
+    filter.filter(end_event)
+
+    filter.start_events["1"].end["@timestamp"] = filter.start_events["1"].start["@timestamp"] + 34
+
+    filter.flush()
+  
+    event = filter.last_new_event
+    insist { event } != nil
+    insist { event["tags"][0] } == "lazy_elapsed_match"
+    insist { event["message3"] } == end_event_data["message3"]
+    insist { event["message4"] } == end_event_data["message4"]
+    insist { event["message"] } == nil
+    insist { event["message2"] } == nil
+    insist { event["elapsed_time"] } == 34000
+  end
+
+
+  it "does nothing if the field is not there to copy from the end event" do
+    config = {"start_tag" => START_TAG,
+               "end_tag" => END_TAG,
+               "unique_id_field" => UNIQUE_ID_FIELD,
+               "timestamp_field" => "@timestamp",
+               "fields_to_copy_from_end" => ["message", "message3", "message4"],
+               "time_to_wait" => 2} 
+    filter = LogStash::Filters::LazyElapsed.new(config)
+    filter.register
+  
+    start_event_data = {
+      "tags" => [ START_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "message" => "some log message",
+      "message2" => "some other log message"
+    }
+    
+    start_event = LogStash::Event.new(start_event_data)
+
+    end_event_data = {
+      "tags" => [ END_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "message" => "some extra log message",
+      "message2" => "another log message"
+    }
+
+    end_event = LogStash::Event.new(end_event_data)
+
+    filter.filter(start_event)
+    filter.filter(end_event)
+
+    filter.flush()
+  
+    event = filter.last_new_event
+    insist { event } != nil
+    insist { event["tags"][0] } == "lazy_elapsed_match"
+    insist { event["message"] } == end_event_data["message"] 
+    insist { event["message"] } != start_event_data["message"] 
+    insist { event["message3"] } == nil 
+    insist { event["message4"] } == nil
+  end
+
+
+  it "increments age correctly on a flush" do
+    config = {"start_tag" => START_TAG,
+               "end_tag" => END_TAG,
+               "unique_id_field" => UNIQUE_ID_FIELD,
+               "timestamp_field" => "@timestamp"} 
+    filter = LogStash::Filters::LazyElapsed.new(config)
+    filter.register
+  
+    event_data = {
+      "tags" => [ START_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "message" => "some log message"
+    }
+    
+    start_event = LogStash::Event.new(event_data)
+
+    filter.filter(start_event)
+
+    insist { filter.start_events["1"].age } == 0
+    
+    filter.flush()
+    insist { filter.start_events["1"].age } == 5
+
+    filter.flush()
+    insist { filter.start_events["1"].age } == 10
+  end
+
+
+  it "records fields from the events correctly" do
+    config = {"start_tag" => START_TAG,
+               "end_tag" => END_TAG,
+               "unique_id_field" => UNIQUE_ID_FIELD,
+               "timestamp_field" => "@timestamp",
+               "fields_to_record" => {"messages" => "message", 
+                                      "messages2" => "message2",
+                                      "messages3" => "message3"},
+               "time_to_wait" => 2} 
+    filter = LogStash::Filters::LazyElapsed.new(config)
+    filter.register
+  
+    start_event_data = {
+      "tags" => [ START_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "message" => "first message",
+      "message2" => "first message2"
+    }
+    
+    start_event = LogStash::Event.new(start_event_data)
+
+    end_event_data1 = {
+      "tags" => [ END_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "message" => "second message",
+      "message4" => "we shouldn't see this one"
+    }
+
+    end_event1 = LogStash::Event.new(end_event_data1)
+
+    end_event_data2 = {
+      "tags" => [ END_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "message" => "third message",
+      "message2" => "second message2"
+    }
+
+    end_event2 = LogStash::Event.new(end_event_data2)
+
+    filter.filter(start_event)
+    filter.filter(end_event1)
+    filter.filter(end_event2)
+
+    filter.flush()
+
+    event = filter.last_new_event
+    insist { event } != nil
+    insist { event["tags"][0] } == "lazy_elapsed_match"
+    insist { event["messages"].size } == 3
+    insist { event["messages"][0] } == start_event_data["message"] 
+    insist { event["messages"][1] } == end_event_data1["message"] 
+    insist { event["messages"][2] } == end_event_data2["message"] 
+    insist { event["messages2"].size } == 2 
+    insist { event["messages2"][0] } == start_event_data["message2"] 
+    insist { event["messages2"][1] } == end_event_data2["message2"] 
+    insist { event["messages3"] } == nil
+    insist { event["message4"] } == nil
+  end 
+
+
+  it "sums fields from the events correctly" do
+    config = {"start_tag" => START_TAG,
+               "end_tag" => END_TAG,
+               "unique_id_field" => UNIQUE_ID_FIELD,
+               "timestamp_field" => "@timestamp",
+               "fields_to_sum" => {"sum" => "time", 
+                                   "sum2" => "time2",
+                                   "sum3" => "time3"},
+               "time_to_wait" => 2} 
+    filter = LogStash::Filters::LazyElapsed.new(config)
+    filter.register
+  
+    start_event_data = {
+      "tags" => [ START_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "time" => 23,
+      "time2" => 85
+    }
+    
+    start_event = LogStash::Event.new(start_event_data)
+
+    end_event_data1 = {
+      "tags" => [ END_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "time" => 18,
+      "time4" => 1345
+    }
+
+    end_event1 = LogStash::Event.new(end_event_data1)
+
+    end_event_data2 = {
+      "tags" => [ END_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "time" => 10045,
+      "time2" => 90094
+    }
+
+    end_event2 = LogStash::Event.new(end_event_data2)
+
+    filter.filter(start_event)
+    filter.filter(end_event1)
+    filter.filter(end_event2)
+
+    filter.flush()
+
+    event = filter.last_new_event
+    insist { event } != nil
+    insist { event["tags"][0] } == "lazy_elapsed_match"
+    insist { event["sum"] } == start_event_data["time"] + end_event_data1["time"] + end_event_data2["time"]
+    insist { event["sum2"] } == start_event_data["time2"] + end_event_data2["time2"]
+    insist { event["sum3"] } == nil
+    insist { event["time4"] } ==  nil
+  end
+
+  it "supports the timestamp being a string" do
+    config = {"start_tag" => START_TAG,
+               "end_tag" => END_TAG,
+               "unique_id_field" => UNIQUE_ID_FIELD,
+               "timestamp_field" => "mytimestamp",
+               "time_to_wait" => 2} 
+    filter = LogStash::Filters::LazyElapsed.new(config)
+    filter.register
+  
+    start_event_data = {
+      "tags" => [ START_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "mytimestamp" => "Wed Aug 27 16:03:41 MDT 2014"
+    }
+    
+    start_event = LogStash::Event.new(start_event_data)
+
+    end_event_data = {
+      "tags" => [ END_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "mytimestamp" => "2014/08/27 16:05:43"
+    }
+
+    end_event = LogStash::Event.new(end_event_data)
+
+    filter.filter(start_event)
+    filter.filter(end_event)
+
+    filter.flush()
+
+    event = filter.last_new_event
+    insist { event } != nil
+    insist { event["tags"][0] } == "lazy_elapsed_match"
+    insist { event["elapsed_time"] } == 122000 
+  end
+
+  it "doesn't crash if it can't parse the timestamp string" do
+    config = {"start_tag" => START_TAG,
+               "end_tag" => END_TAG,
+               "unique_id_field" => UNIQUE_ID_FIELD,
+               "timestamp_field" => "mytimestamp",
+               "time_to_wait" => 2} 
+    filter = LogStash::Filters::LazyElapsed.new(config)
+    filter.register
+  
+    start_event_data = {
+      "tags" => [ START_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "mytimestamp" => "This is not a timestamp"
+    }
+    
+    start_event = LogStash::Event.new(start_event_data)
+
+    end_event_data = {
+      "tags" => [ END_TAG ],
+      UNIQUE_ID_FIELD => "1",
+      "mytimestamp" => "dsfhjkekldddkskskjdj"
+    }
+
+    end_event = LogStash::Event.new(end_event_data)
+
+    filter.filter(start_event)
+    filter.filter(end_event)
+
+    filter.flush()
+    event = filter.last_new_event
+    insist { event } != nil
+    insist { event["tags"][0] } == "lazy_elapsed_match"
+    insist { event["elapsed_time"] } == 0 
+  end
+end


### PR DESCRIPTION
For some metrics gathering I needed a filter like the Elapsed filter, but I needed it to be lazy about how it picked the ending event since in my situation I would receive multiple end events that may come in any order or might not come at all. I also needed to record pieces of each event seen and also tally up a numerical field from each event. So, I created the Lazy Elapsed filter to solve my problems and I figured it might solve someone else's problems as well. 

This pull request adds the new filter and it's associated tests. 

Thank you for your consideration and comments.
