### PR TITLE
Update wms_fields

### DIFF
--- a/lib/logstash/filters/wms.rb
+++ b/lib/logstash/filters/wms.rb
@@ -38,7 +38,8 @@ class LogStash::Filters::Wms < LogStash::Filters::Base
   config :wms_fields, :validate => :array, :default => [
     'service', 'version', 'request', 'layers', 'styles', 'crs', 'srs',
     'bbox', 'width', 'height', 'format', 'transparent', 'bgcolor',
-    'bgcolor', 'exceptions', 'time', 'elevation', 'wfs' 
+    'exceptions', 'time', 'elevation', 'updatesequence', 'query_layers',
+    'info_format', 'feature_count', 'i', 'j', 'x', 'y', 'sld', 'wfs'
   ]
 
   # prefix for parsed elements added by the plugin


### PR DESCRIPTION
This removes bgcolor which was mentionned twice, and adds more parameters from the 1.1.1 and 1.3.0 OGC standards