### PR TITLE
Bug // Compress Spooler will no longer drop messages - issue#110

### DIFF
--- a/lib/logstash/codecs/compress_spooler.rb
+++ b/lib/logstash/codecs/compress_spooler.rb
@@ -29,14 +29,14 @@ class LogStash::Codecs::CompressSpooler < LogStash::Codecs::Base
 
   public
   def encode(data)
+    data["@timestamp"] = data["@timestamp"].to_f
+    @buffer << data.to_hash
+
     if @buffer.length >= @spool_size
       z = Zlib::Deflate.new(@compress_level)
       @on_event.call z.deflate(MessagePack.pack(@buffer), Zlib::FINISH)
       z.close
       @buffer.clear
-    else
-      data["@timestamp"] = data["@timestamp"].to_f
-      @buffer << data.to_hash
     end
   end # def encode
 


### PR DESCRIPTION
When the last message is ready to be spooled, compressed spooler will
drop the message it's currently processing and push out the spool. If
your spool size is 10, this means on the 11th message it will send that
spool.

This changes the logic to add the message to the spool, and then
immediately send it if it's the right size.
