### PR TITLE
Adding tls-tcp mode to syslog output.

### DIFF
--- a/lib/logstash/outputs/syslog.rb
+++ b/lib/logstash/outputs/syslog.rb
@@ -2,6 +2,7 @@
 require "logstash/outputs/base"
 require "logstash/namespace"
 require "date"
+require "openssl"
 
 
 # Send events to a syslog server.
@@ -52,12 +53,12 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
 
   # syslog server address to connect to
   config :host, :validate => :string, :required => true
-  
+
   # syslog server port to connect to
   config :port, :validate => :number, :required => true
 
-  # syslog server protocol. you can choose between udp and tcp
-  config :protocol, :validate => ["tcp", "udp"], :default => "udp"
+  # syslog server protocol. you can choose between UDP, TCP, or TLS over TCP
+  config :protocol, :validate => ["tcp", "udp", "tls-tcp"], :default => "udp"
 
   # facility label for syslog message
   config :facility, :validate => FACILITY_LABELS, :required => true
@@ -76,36 +77,45 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
 
   # process id for syslog message
   config :procid, :validate => :string, :default => "-"
- 
+
   # message id for syslog message
   config :msgid, :validate => :string, :default => "-"
 
   # syslog message format: you can choose between rfc3164 or rfc5424
   config :rfc, :validate => ["rfc3164", "rfc5424"], :default => "rfc3164"
 
-  
+
   public
   def register
-      @client_socket = nil
-  end
-
-  private
-  def udp?
-    @protocol == "udp"
+    @client_socket = nil
+    @last_message_sent = 0
+    @num_retries = (Integer ENV['SYSLOG_MAX_RETRIES'] rescue nil) || 3
+    @timeout = (Integer ENV['SYSLOG_CONNECTION_TIMEOUT_SECONDS'] rescue nil) || 30
   end
 
   private
   def rfc3164?
     @rfc == "rfc3164"
-  end 
+  end
 
   private
   def connect
-    if udp?
+    @client_socket.close rescue nil if @client_socket
+    if @protocol == 'udp'
         @client_socket = UDPSocket.new
         @client_socket.connect(@host, @port)
     else
         @client_socket = TCPSocket.new(@host, @port)
+        if @protocol == 'tls-tcp'
+            ssl = OpenSSL::SSL::SSLContext.new
+            ssl.verify_mode = OpenSSL::SSL::VERIFY_PEER
+            cert_store = OpenSSL::X509::Store.new
+            cert_store.set_default_paths
+            ssl.cert_store = cert_store
+            @client_socket = OpenSSL::SSL::SSLSocket.new(@client_socket, ssl)
+            @client_socket.sync_close = true
+        end
+        @client_socket.connect
     end
   end
 
@@ -132,15 +142,20 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
       syslog_msg = "<"+priority.to_s()+">1 "+timestamp+" "+sourcehost+" "+appname+" "+procid+" "+msgid+" - "+event["message"]
     end
 
-    begin
-      connect unless @client_socket
-      @client_socket.write(syslog_msg + "\n")
-    rescue => e
-      @logger.warn(@protocol+" output exception", :host => @host, :port => @port,
-                 :exception => e, :backtrace => e.backtrace)
-      @client_socket.close rescue nil
-      @client_socket = nil
+    @num_retries.times do |attempt|
+      begin
+        now = Time.now
+        connect unless @client_socket && (now - @last_message_sent) < @timeout
+        @client_socket.write(syslog_msg + "\n")
+        @last_message_sent = now
+        return
+      rescue => e
+        @logger.warn(@protocol+" output exception on attempt #{attempt}",
+                     :host => @host, :port => @port,
+                     :exception => e, :backtrace => e.backtrace)
+        @client_socket.close rescue nil
+        @client_socket = nil
+      end
     end
   end
 end
-


### PR DESCRIPTION
This patch lets you send syslog messages from logstash using TLS over TCP. This is the preferred way to send syslog over TCP ([RFC 5424](https://tools.ietf.org/html/rfc5424), 5.1 says "All implementations of this specification MUST support a TLS-based transport as described in [RFC5425].").

I tested this by forwarding messages to Papertrail (configured to only use TLS over TCP) from a logstash agent with 'tls-tcp' syslog configured.