### PR TITLE
Make the zeromq filter actualy work

### DIFF
--- a/lib/logstash/filters/zeromq.rb
+++ b/lib/logstash/filters/zeromq.rb
@@ -1,6 +1,8 @@
 # encoding: utf-8
 require "logstash/filters/base"
 require "logstash/namespace"
+require "logstash/event"
+require "json"
 
 # ZeroMQ filter. This is the best way to send an event externally for filtering
 # It works much like an exec filter would by sending the event "offsite"
@@ -194,7 +196,7 @@ class LogStash::Filters::ZeroMQ < LogStash::Filters::Base
         filter_matched(event)
       else
         reply = JSON.parse(reply)
-        event.overwrite(reply)
+        event.overwrite(LogStash::Event.new(reply))
       end
       filter_matched(event)
       #if message send/recv was not successful add the timeout


### PR DESCRIPTION
Two changes:
1) The existing code calls JSON.parse() without importing json. Fixed.
2) The existing code calls event.overwrite() with a Hash param, rather than a LogStash::Event.  The overwrite() method expects an Event, so this can't work (see code in event.rb).  The zeromq server can only reply with a JSON object, so the Hash reply from JSON.parse() needs to be made into an Event before being used in overwrite()

I'm new to both Logstash and Ruby, but the zeromq filter didn't work at all as is, and works with this patch.