### PR TITLE
removed validator on metric_type

### DIFF
--- a/lib/logstash/outputs/datadog_metrics.rb
+++ b/lib/logstash/outputs/datadog_metrics.rb
@@ -27,7 +27,7 @@ class LogStash::Outputs::DatadogMetrics < LogStash::Outputs::Base
   config :metric_value, :default => "%{metric_value}"
 
   # The type of the metric.
-  config :metric_type, :validate => ["gauge", "counter", "%{metric_type}"], :default => "%{metric_type}"
+  config :metric_type, :default => "%{metric_type}"
 
   # The name of the host that produced the metric.
   config :host, :validate => :string, :default => "%{host}"


### PR DESCRIPTION
want to be able to do %{sub.metric_type}
