### PR TITLE
Changed bigquery output interval to 90 seconds by default

### DIFF
--- a/lib/logstash/outputs/google_bigquery.rb
+++ b/lib/logstash/outputs/google_bigquery.rb
@@ -73,8 +73,8 @@ require "logstash/namespace"
 #      temp_file_prefix => "logstash_bq"                         (optional)
 #      date_pattern => "%Y-%m-%dT%H:00"                          (optional)
 #      flush_interval_secs => 2                                  (optional)
-#      uploader_interval_secs => 60                              (optional)
-#      deleter_interval_secs => 60                               (optional)
+#      uploader_interval_secs => 90                              (optional)
+#      deleter_interval_secs => 90                               (optional)
 #    }
 # }
 #


### PR DESCRIPTION
BigQuery has a hard limit [1] of 1000 load jobs per query per day, running every 60 seconds hits this limit.
- 60m \* 24h => 1440 calls per day.
- (60m / 1.5m) \* 24h => 960 calls per day (within limit).

[1] - https://cloud.google.com/bigquery/quota-policy
