### PR TITLE
Add a bit more detail to setup instructions for GCS plugin

### DIFF
--- a/lib/logstash/outputs/google_cloud_storage.rb
+++ b/lib/logstash/outputs/google_cloud_storage.rb
@@ -28,8 +28,8 @@ require "zlib"
 # For more info on Google Cloud Storage, please go to:
 # https://cloud.google.com/products/cloud-storage
 #
-# In order to use this plugin, a Google service account must be used. For
-# more information, please refer to:
+# In order to use this plugin, a Google service account must be used and have
+# Writer access to the bucket. For more information, please refer to:
 # https://developers.google.com/storage/docs/authentication#service_accounts
 #
 # Recommendation: experiment with the settings depending on how much log


### PR DESCRIPTION
A few users have run into issues because the instructions did not specify write access was needed ahead of time. Making a quick fix to ensure this doesn't happen with anyone else.
